### PR TITLE
Fix authinfo token retrieval in org-asana--make-request

### DIFF
--- a/org-asana.el
+++ b/org-asana.el
@@ -764,8 +764,7 @@ If nil, will attempt to retrieve from authinfo."
 
 (defun org-asana--make-request (method endpoint &optional data)
   "Make an API request to METHOD ENDPOINT with optional DATA."
-  (unless org-asana-token
-    (signal 'org-asana-auth-error '("No Asana token configured. Set `org-asana-token'")))
+  (org-asana--validate-token)
   (org-asana--check-rate-limit)
   (let* ((url (org-asana--build-request-url endpoint))
          (headers (org-asana--build-request-headers))


### PR DESCRIPTION
## Summary
- Fixed authentication issue where `org-asana--make-request` was checking `org-asana-token` directly instead of using the token retrieval mechanism
- This prevented the package from working with authinfo authentication when `org-asana-token` was set to `nil`

## Changes
- Replaced direct `org-asana-token` check with `org-asana--validate-token` call in `org-asana--make-request`
- This allows the function to properly retrieve tokens from authinfo when `org-asana-token` is nil

## Test plan
- [x] Set `org-asana-token` to `nil` in configuration
- [x] Add token to ~/.authinfo.gpg with format: `machine app.asana.com login apikey password <token>`
- [x] Run `M-x org-asana-test-connection` to verify authentication works
- [x] Run `M-x org-asana-sync` to verify full sync works with authinfo