### PR TITLE
fix: Handle list values in org properties drawer

### DIFF
--- a/org-asana.el
+++ b/org-asana.el
@@ -1036,7 +1036,12 @@ If nil, will attempt to retrieve from authinfo."
   (insert ":PROPERTIES:\n")
   (dolist (prop properties)
     (when (cdr prop)
-      (insert ":" (car prop) ": " (cdr prop) "\n")))
+      (let ((value (cdr prop)))
+        (insert ":" (car prop) ": " 
+                (if (listp value)
+                    (mapconcat #'identity value ", ")
+                  value)
+                "\n"))))
   (insert ":END:\n"))
 
 (defun org-asana--insert-body (body)


### PR DESCRIPTION
## Summary
- Fixed an issue where list values (e.g., multiple followers) caused "Wrong type argument: char-or-string-p" errors during sync
- Modified `org-asana--insert-properties` to properly convert list values to comma-separated strings

## Test plan
- [x] Tested locally with tasks containing multiple followers
- [x] Verified that sync completes without errors
- [x] Confirmed that follower lists are properly displayed in org properties as comma-separated values