### PR TITLE
Fix byte-compilation warnings and errors

### DIFF
--- a/org-asana-attachments.el
+++ b/org-asana-attachments.el
@@ -235,8 +235,7 @@
           (let ((link (org-element-context)))
             (when (eq (org-element-type link) 'link)
               (let ((begin (org-element-property :begin link))
-                    (end (org-element-property :end link))
-                    (desc (org-element-property :raw-link link)))
+                    (end (org-element-property :end link)))
                 (delete-region begin end)
                 (insert (format "[[file:%s][%s]]" local-path
                                (alist-get 'name attachment)))))))))))

--- a/org-asana-browser.el
+++ b/org-asana-browser.el
@@ -24,6 +24,7 @@
 
 (require 'org-asana)
 (require 'tabulated-list)
+(require 'org-asana-users nil t)
 
 ;;; Custom Variables
 
@@ -328,8 +329,7 @@
 (defun org-asana-browse-my-tasks ()
   "Browse my tasks."
   (interactive)
-  (let* ((workspace-gid (cadr (org-asana--fetch-workspace-info)))
-         (me (org-asana--fetch-current-user))
+  (let* ((me (org-asana--fetch-current-user))
          (my-gid (alist-get 'gid me)))
     (setq org-asana-browser--current-project nil)
     (setq org-asana-browser--current-filter `(:assignee ,my-gid))

--- a/org-asana-subtasks.el
+++ b/org-asana-subtasks.el
@@ -226,7 +226,7 @@
 ;;; Creation Handling
 
 (defun org-asana--handle-new-subtasks ()
-  "Handle creation of new subtasks marked with 'new' GID."
+  "Handle creation of new subtasks marked with `new' GID."
   (org-map-entries
    (lambda ()
      (let ((gid (org-entry-get (point) "ASANA-TASK-GID"))

--- a/org-asana-types.el
+++ b/org-asana-types.el
@@ -243,10 +243,10 @@
   (insert (org-asana--format-task-title-with-type
            `((name . ,title)
              (resource_subtype . "section"))))
-    (org-set-property "ASANA-TASK-GID" "new")
-    (org-set-property "ASANA-TYPE" "section")
-    (org-set-property "ASANA-SEPARATOR" "t")
-    (message "Separator created. Run sync to create in Asana.")))
+  (org-set-property "ASANA-TASK-GID" "new")
+  (org-set-property "ASANA-TYPE" "section")
+  (org-set-property "ASANA-SEPARATOR" "t")
+  (message "Separator created. Run sync to create in Asana."))
 
 ;;; Filtering Functions
 


### PR DESCRIPTION
## Summary
- Fixed all byte-compilation errors and warnings
- Ensured all parentheses are balanced
- Package now compiles cleanly

## Changes
- Fixed syntax error in `org-asana-types.el` line 249 (removed extra closing paren)
- Removed unused lexical variable `desc` in `org-asana-attachments.el`
- Removed unused lexical variable `workspace-gid` in `org-asana-browser.el`
- Added missing require for `org-asana-users` in browser module
- Fixed docstring quote usage in `org-asana-subtasks.el`

## Test Results
```
✓ All .el files compile without errors
✓ All parentheses are balanced
✓ All modules load successfully
✓ test-org-asana.el passes all module loading tests
```

## Verification
```bash
# Clean compile test
rm -f *.elc && emacs -batch -L . -f batch-byte-compile *.el

# Balance check  
for file in *.el; do
  emacs -batch -Q --eval "(progn (find-file \"$file\") (check-parens))"
done
```